### PR TITLE
Remove unused dependency from package-lock.json

### DIFF
--- a/socket/package-lock.json
+++ b/socket/package-lock.json
@@ -12,11 +12,6 @@
         "socket.io": "^4.7.5"
       }
     },
-    "node_modules/@socket.io/component-emitter": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
-      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
-    },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",


### PR DESCRIPTION
Removed unused dependency '@socket.io/component-emitter' from package-lock.json.