### PR TITLE
Remove deprecated @prisma/get-platform module

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -98,15 +98,6 @@
         "@prisma/get-platform": "5.22.0"
       }
     },
-    "node_modules/@prisma/get-platform": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
-      "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/debug": "5.22.0"
-      }
-    },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",


### PR DESCRIPTION
Removed deprecated @prisma/get-platform module from package-lock.